### PR TITLE
Safer singleton, move addListener to onCreate

### DIFF
--- a/changeskin/src/main/java/com/zhy/changeskin/SkinManager.java
+++ b/changeskin/src/main/java/com/zhy/changeskin/SkinManager.java
@@ -41,18 +41,13 @@ public class SkinManager
     {
     }
 
-    private static SkinManager sInstance;
+    private static class SingletonHolder {
+        static SkinManager sInstance = new SkinManager();
+    }
 
     public static SkinManager getInstance()
     {
-        if (sInstance == null)
-        {
-            synchronized (SkinManager.class)
-            {
-                sInstance = new SkinManager();
-            }
-        }
-        return sInstance;
+        return SingletonHolder.sInstance;
     }
 
 

--- a/changeskin/src/main/java/com/zhy/changeskin/base/BaseSkinActivity.java
+++ b/changeskin/src/main/java/com/zhy/changeskin/base/BaseSkinActivity.java
@@ -2,6 +2,7 @@ package com.zhy.changeskin.base;
 
 import android.content.Context;
 import android.os.Build;
+import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.util.ArrayMap;
 import android.support.v4.view.ViewCompat;
@@ -203,9 +204,9 @@ public class BaseSkinActivity extends AppCompatActivity implements ISkinChangedL
 
 
     @Override
-    protected void onResume()
+    protected void onCreate(@Nullable Bundle savedInstanceState)
     {
-        super.onResume();
+        super.onCreate(savedInstanceState);
         SkinManager.getInstance().addChangedListener(this);
     }
 


### PR DESCRIPTION
A safer singleton pattern, move addChangedListener to onCreate, prevent
adding too many times.
